### PR TITLE
Update Android instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ We’ll be looking for clean, well-structured code and a polished user interface
 
 ##### Android
 
-Use Java with standard Android XML layouts. You can use any libraries and tools you like. Volley and Glide are not required but recommended. 
+Use Java with standard Android XML layouts. You can use any libraries and tools you like, but be prepared to explain why.
 
-Send us the APK file so we can install on Android 4 or 5 and a link to your code repo. We want to see the details.
+Send us the APK file and a link to your code repo.
 
 ##### iOS
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We’ll be looking for clean, well-structured code and a polished user interface
 
 ##### Android
 
-Use Java with standard Android XML layouts. You can use any libraries and tools you like, but be prepared to explain why.
+Use Java with standard Android XML layouts. You can use any libraries and tools you like, but please include a README that explains your approach and why specific technologies were used.
 
 Send us the APK file and a link to your code repo.
 


### PR DESCRIPTION
This simplifies the Android instructions. We don't want to encourage users to use Volley since we are moving to Retrofit, but I think it's fine to let the candidate chose the library on their own. Also, we don't need to mention which Android version we will be testing on. We can leave it up to them to set the minimum SDK version and ask them to explain why if necessary.