### PR TITLE
Clarify that candidates should pick an exercise appropriate to their application

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ If you have existing code that you can share with us and are proud of, these exe
 
 ## Turo Code Exercises
 
-If you are doing an exercise, you can pick any of the ones below. You should plan on spending 30–120 minutes on the exercise.
+If you are doing an exercise, please choose an exercise appropriate to the position for which you are applying (i.e. please don't do the iOS exercise if you're applying for an Android role). You should plan on spending 30–120 minutes on the exercise.
 
 ### Server (Full-Stack)
 


### PR DESCRIPTION
This change clarifies that candidates should choose an exercise appropriate to the role for which they're applying. Although most candidates have done this on their own, we've had a couple instances where candidates chose an exercise that was difficult for the interview team to assess. By narrowing the instructions, we hope to minimize the chances of that happening in the future.